### PR TITLE
Remove the pending intent mutable flag to reproduce the crash.

### DIFF
--- a/app/src/main/java/com/example/android/notificationchannels/MainActivity.java
+++ b/app/src/main/java/com/example/android/notificationchannels/MainActivity.java
@@ -122,14 +122,14 @@ public class MainActivity extends Activity {
   @Nullable
   private PendingIntent immutablePendingIntent(String extraValue) {
     Intent notifyIntent = DetailActivity.constructIntent(this, extraValue);
-    return PendingIntent.getActivity(this, 0, notifyIntent, PendingIntent.FLAG_IMMUTABLE);
+    return PendingIntent.getActivity(this, 0, notifyIntent, 0);
   }
 
   @SuppressLint("InlinedApi")
   @Nullable
   private PendingIntent mutablePendingIntent(String extraValue) {
     Intent notifyIntent = DetailActivity.constructIntent(this, extraValue);
-    return PendingIntent.getActivity(this, 0, notifyIntent, PendingIntent.FLAG_MUTABLE);
+    return PendingIntent.getActivity(this, 0, notifyIntent, 0);
   }
 
   /** Send Intent to load system Notification Settings for this app. */


### PR DESCRIPTION
> Process: com.example.android.notificationchannels, PID: 30267
    java.lang.IllegalArgumentException: com.example.android.notificationchannels: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:382)
        at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:465)
        at android.app.PendingIntent.getActivity(PendingIntent.java:451)
        at android.app.PendingIntent.getActivity(PendingIntent.java:415)
        at com.example.android.notificationchannels.MainActivity.immutablePendingIntent(MainActivity.java:125)
        at com.example.android.notificationchannels.MainActivity.sendNotification(MainActivity.java:85)
        at com.example.android.notificationchannels.MainActivity$MainUi.onClick(MainActivity.java:193)